### PR TITLE
Casting

### DIFF
--- a/src/ir.rs
+++ b/src/ir.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{config, logging, parser, Spanned};
+use crate::{logging, parser, Spanned};
 use colored::Colorize;
 
 #[derive(Debug, Clone)]
@@ -593,6 +593,11 @@ pub enum Instr {
         args: Vec<Value>,
         into: Option<TempIndex>,
     },
+    Cast {
+        v: Value,
+        into_type: Type,
+        into_index: TempIndex,
+    }
 }
 
 impl std::fmt::Display for Instr {
@@ -639,6 +644,9 @@ impl std::fmt::Display for Instr {
             }
             Self::Return { v } => {
                 write!(f, "Return {v:?}")
+            }
+            Self::Cast { v, into_type, into_index } => {
+                write!(f, "Temp[{into_index}] = Cast({v:?}, into {into_type:?})")
             }
         }
     }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -428,6 +428,13 @@ impl Function {
                     i: place,
                 })
             }
+            parser::Expression::Cast { value, to } => {
+                let dest_type = type_from_type_name(&to);
+                let place = self.alloc_temp(dest_type.clone());
+                let v = self.add_expr(value, funcs)?;
+                self.body.push(Instr::Cast { v, into_type: dest_type.clone(), into_index: place });
+                Ok(Value::Temp { t: dest_type, i: place })
+            }
         }
     }
     fn alloc_temp(&mut self, t: Type) -> TempIndex {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -41,7 +41,8 @@ pub enum Keyword {
     If,
     While,
     Func,
-    Extern
+    Extern,
+    Cast,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -187,6 +188,12 @@ impl<'a> Lexer<'a> {
                             len: end - begin,
                             line_beginning: begin_line,
                             v: Token::Keyword(Keyword::Extern),
+                        }),
+                        "cast" => tokens.push(Spanned {
+                            offset: begin,
+                            len: end - begin,
+                            line_beginning: begin_line,
+                            v: Token::Keyword(Keyword::Cast),
                         }),
                         _ => tokens.push(Spanned {
                             offset: begin,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -525,8 +525,7 @@ impl<'a> Parser<'a> {
                 let t_name = self.expect_name()?;
                 self.expect_token(Token::Comma)?;
                 let value = self.parse_expression()?;
-                self.expect_token(Token::CloseParen)?;
-                let end = self.expect_token(Token::Semicolon)?;
+                let end = self.expect_token(Token::CloseParen)?;
                 Ok(Spanned { offset: offset, len: end.offset - offset, line_beginning, v: Expression::Cast { value: Box::new(value), to: t_name.v } }) 
             }
             None => Err(self.spanned_error_from_last_tk(Error::ExpectedExpression)),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -520,6 +520,15 @@ impl<'a> Parser<'a> {
 
                 Ok(expr)
             }
+            Some(Spanned { offset, line_beginning, v: Token::Keyword(Keyword::Cast), .. }) => {
+                self.expect_token(Token::OpenParen)?;
+                let t_name = self.expect_name()?;
+                self.expect_token(Token::Comma)?;
+                let value = self.parse_expression()?;
+                self.expect_token(Token::CloseParen)?;
+                let end = self.expect_token(Token::Semicolon)?;
+                Ok(Spanned { offset: offset, len: end.offset - offset, line_beginning, v: Expression::Cast { value: Box::new(value), to: t_name.v } }) 
+            }
             None => Err(self.spanned_error_from_last_tk(Error::ExpectedExpression)),
             Some(_) => Err(self.spanned_error_from_last_tk(Error::UnexpectedToken)),
         }
@@ -752,6 +761,10 @@ pub enum Expression {
         name: String,
         args: Vec<Spanned<Expression>>,
     },
+    Cast {
+        value: Box<Spanned<Expression>>,
+        to: String
+    }
 }
 
 pub enum Error {


### PR DESCRIPTION
Added cast built in function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for explicit type casting expressions using the `cast(type_name, expression)` syntax.
  * Extended language keywords to include `cast`.
  * Enabled code generation for integer truncation and zero-extension casts between types.

* **Bug Fixes**
  * Removed an unused import to improve code cleanliness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->